### PR TITLE
Aplicação de CI

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Workflow de Integração Contínua
+
+on:
+  push:
+    branches: [ "main", "devops-git"]
+  pull_request:
+    branches: [ "main", "devops-git" ]
+
+jobs:
+  continuous-integration:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.
+        
+    - name: Instalar dependências
+      run: npm install
+      working-directory: devops/github/allbooks
+      
+    - name: Executar testes
+      run: npm test
+      working-directory: devops/github/allbooks


### PR DESCRIPTION
Atendendo o issue #2, que pede aplicação de CI ao projeto allbooks. O CI ficará limitado à branch devops-git que atende às  necessidades do curso de GitHub do módulo de introdução ao DevOps.